### PR TITLE
feat: split dashboard view into separate partials, progressively reveal actions

### DIFF
--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -19,6 +19,18 @@ class UserController extends Controller
     }
 
     /**
+     * Show the dashboard view for the logged-in user.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function dashboard()
+    {
+        return view('dashboard', [
+            'currentUser' => Auth::user(),
+        ]);
+    }
+
+    /**
      * Show the profile edit view for the logged-in user.
      *
      * @return \Illuminate\View\View

--- a/resources/views/dashboard.blade.php
+++ b/resources/views/dashboard.blade.php
@@ -2,132 +2,15 @@
     <x-slot name="title">{{ __('My dashboard') }}</x-slot>
     <x-slot name="header">
         <h1 itemprop="name">
-            <small>{{ Auth::user()->name }}@if(Auth::user()->entity()), {{ Auth::user()->entity()->name }}@endif</small><br />
+            <small>{{ $currentUser->name }}@if($currentUser->entity()), {{ $currentUser->entity()->name }}@endif</small><br />
             {{ __('My dashboard') }}
         </h1>
     </x-slot>
 
-    @if(Auth::user()->context === 'consultant')
-        <div class="columns">
-            <div class="column flow">
-                <div class="box flow">
-                    <h2>{{ __('Getting started') }}</h2>
-                    @if(!Auth::user()->consultant)
-                    <x-expander level="3">
-                        <x-slot name="summary">{{ __('Create your community member page') }}</x-slot>
-                        <div class="flow">
-                            <p>{{ __('Once you create your page, entities can find you and ask you to consult on their projects.') }}</p>
-                            <p><a class="button" href="{{ localized_route('consultants.create') }}">{{ __('Create your page') }}</a></p>
-                        </div>
-                    </x-expander>
-                    @endif
-                    <x-expander level="3">
-                        <x-slot name="summary">{{ __('Find entities to follow') }}</x-slot>
-                        <div class="flow">
-                            <p>{{ __('Once you follow some entities that you’re interested in, you will be notified whenever they begin a community consultation process.') }}</p>
-                            <p><a class="button" href="{{ localized_route('entities.index') }}">{{ __('Find entities') }}</a></p>
-                        </div>
-                    </x-expander>
-                    <x-expander level="3">
-                        <x-slot name="summary">{{ __('Learn about participating in consultations') }}</x-slot>
-                        <div class="flow">
-                            <p>{{ __('Find resources about the accessibility planning process and how you can participate in it.') }}</p>
-                            <p><a class="button" href="{{ localized_route('collections.index') }}">{{ __('Explore the resource hub') }}</a></p>
-                        </div>
-                    </x-expander>
-                </div>
-
-                @if(Auth::user()->consultant)
-                <div class="box flow">
-                    <h2>{{ __('My page') }}</h2>
-                    <p>
-                        <a href="{{ localized_route('consultants.show', ['consultant' => Auth::user()->consultant]) }}"><strong>{{ __('Visit my page') }}</strong>@if(Auth::user()->consultant->checkStatus('draft')) ({{ __('draft') }})@endif</a><br />
-                        <a href="{{ localized_route('consultants.edit', ['consultant' => Auth::user()->consultant]) }}">{{ __('Edit my page') }}</a>
-                    </p>
-                </div>
-                @endif
-
-                <div class="box">
-                    <h2>{{ __('Notifications') }} <span class="badge">0</span></h2>
-                </div>
-
-                <div class="box">
-                    <h2>{{ __('Upcoming meetings') }} <span class="badge">0</span></h2>
-                </div>
-            </div>
-
-            <div class="column flow">
-                <div class="box">
-                    <h2>{{ __('My active projects') }}</h2>
-                    @if(Auth::user()->consultant && count(Auth::user()->consultant->projects) > 0)
-                    {{-- TODO: Display project cards. --}}
-                    @else
-                    <p>{!! __('You have no active projects right now. To find a project to work on, :action and express your interest in ones that you want to work on.', ['action' => '<a href="' . localized_route('projects.index') . '">' . __('browse through our list of projects') . '</a>']) !!}</p>
-                    @endif
-                </div>
-            </div>
-        </div>
-    @elseif (Auth::user()->context === 'entity')
-        <div class="columns">
-            <div class="column flow">
-                <div class="box flow">
-                    <h2>{{ __('Getting started') }}</h2>
-                    @if(!Auth::user()->entity())
-                    <x-expander level="3">
-                        <x-slot name="summary">{{ __('Create your entity page') }}</x-slot>
-                        <div class="flow">
-                            <p>{{ __('Share more about your organization so that consultants can get to know you.') }}</p>
-                            <p><a class="button" href="{{ localized_route('entities.create') }}">{{ __('Create your page') }}</a></p>
-                        </div>
-                    </x-expander>
-                    @else
-                    <x-expander level="3">
-                        <x-slot name="summary">{{ __('Create a project page') }}</x-slot>
-                        <div class="flow">
-                            <p>{{ __('Create a new project page so that consultants can begin to express their interest in working with you.') }}</p>
-                            <p><a class="button" href="{{ localized_route('projects.create', Auth::user()->entity()) }}">{{ __('Create project page') }}</a></p>
-                        </div>
-                    </x-expander>
-                    @endif
-                    <x-expander level="3">
-                        <x-slot name="summary">{{ __('Learn about engaging the disability community') }}</x-slot>
-                        <div class="flow">
-                            <p>{{ __('Browse through our resources and learn more.') }}</p>
-                            <p><a class="button" href="{{ localized_route('collections.index') }}">{{ __('Explore the resource hub') }}</a></p>
-                        </div>
-                    </x-expander>
-                </div>
-
-                @if(Auth::user()->entity())
-                <div class="box flow">
-                    <h2>{{ __('My entity page') }}</h2>
-                    <p>
-                        <a href="{{ localized_route('entities.show', Auth::user()->entity()) }}"><strong>{{ __('Visit my entity page') }}</strong><br />
-                        <a href="{{ localized_route('entities.edit', Auth::user()->entity()) }}">{{ __('Edit my entity page') }}</a>
-                    </p>
-                </div>
-                @endif
-
-                <div class="box">
-                    <h2>{{ __('Notifications') }} <span class="badge">0</span></h2>
-                </div>
-
-                <div class="box">
-                    <h2>{{ __('Upcoming meetings') }} <span class="badge">0</span></h2>
-                </div>
-            </div>
-
-            <div class="column flow">
-                <div class="box">
-                    <h2>{{ __('My active projects') }}</h2>
-                    @if(Auth::user()->entity() && count(Auth::user()->entity()->projects) > 0)
-                    {{-- TODO: Display project cards. --}}
-                    @else
-                    <p>{!! __('You have no active projects right now. :action', ['action' => '<strong><a href="' . localized_route('projects.create', Auth::user()->entity()) . '">' . __('Create your first project.') . '</a></strong>']) !!}</p>
-                    @endif
-                </div>
-            </div>
-        </div>
+    @if($currentUser->context === 'consultant')
+        @include('dashboard.community-member')
+    @elseif ($currentUser->context === 'entity')
+        @include('dashboard.entity-representative')
     @endif
 
 </x-app-wide-layout>

--- a/resources/views/dashboard/community-member.blade.php
+++ b/resources/views/dashboard/community-member.blade.php
@@ -1,0 +1,70 @@
+<div class="columns">
+    <div class="column flow">
+        <div class="box flow">
+            <h2>{{ __('Getting started') }}</h2>
+            @if(!$currentUser->consultant)
+            <x-expander level="3">
+                <x-slot name="summary">{{ __('Create your community member page') }}</x-slot>
+                <div class="flow">
+                    <p>{{ __('Once you create your page, entities can find you and ask you to consult on their projects.') }}</p>
+                    <p><a class="button" href="{{ localized_route('consultants.create') }}">{{ __('Create your page') }}</a></p>
+                </div>
+            </x-expander>
+            @else
+            <x-expander level="3">
+                <x-slot name="summary">{{ __('Find entities to follow') }}</x-slot>
+                <div class="flow">
+                    <p>{{ __('Once you follow some entities that you’re interested in, you will be notified whenever they begin a community consultation process.') }}</p>
+                    <p><a class="button" href="{{ localized_route('entities.index') }}">{{ __('Find entities') }}</a></p>
+                </div>
+            </x-expander>
+            @endif
+            <x-expander level="3">
+                <x-slot name="summary">{{ __('Learn about participating in consultations') }}</x-slot>
+                <div class="flow">
+                    <p>{{ __('Find resources about the accessibility planning process and how you can participate in it.') }}</p>
+                    <p><a class="button" href="{{ localized_route('collections.index') }}">{{ __('Explore the resource hub') }}</a></p>
+                </div>
+            </x-expander>
+        </div>
+
+        @if($currentUser->consultant)
+        <div class="box flow">
+            <h2>{{ __('My page') }}</h2>
+            <p>
+                <a href="{{ localized_route('consultants.show', ['consultant' => $currentUser->consultant]) }}"><strong>{{ __('Visit my page') }}</strong>@if($currentUser->consultant->checkStatus('draft')) ({{ __('draft') }})@endif</a><br />
+                <a href="{{ localized_route('consultants.edit', ['consultant' => $currentUser->consultant]) }}">{{ __('Edit my page') }}</a>
+            </p>
+        </div>
+
+        <div class="box">
+            <h2>{{ __('Notifications') }} <span class="badge">0</span></h2>
+        </div>
+
+        <div class="box">
+            <h2>{{ __('Upcoming meetings') }} <span class="badge">0</span></h2>
+        </div>
+        @endif
+    </div>
+
+    <div class="column flow">
+        @if($currentUser->consultant)
+        <div class="box">
+            <h2>{{ __('My active projects') }}</h2>
+            @if(count($currentUser->consultant->projects) > 0)
+            {{-- TODO: Display project cards. --}}
+            @else
+            <p>{!! __('You have no active projects right now. To find a project to work on, :action and express your interest in ones that you want to work on.', ['action' => '<a href="' . localized_route('projects.index') . '">' . __('browse through our list of projects') . '</a>']) !!}</p>
+            @endif
+        </div>
+        @else
+        <div class="box">
+            <h2>{{ __('Notifications') }} <span class="badge">0</span></h2>
+        </div>
+
+        <div class="box">
+            <h2>{{ __('Upcoming meetings') }} <span class="badge">0</span></h2>
+        </div>
+        @endif
+    </div>
+</div>

--- a/resources/views/dashboard/entity-representative.blade.php
+++ b/resources/views/dashboard/entity-representative.blade.php
@@ -1,0 +1,71 @@
+<div class="columns">
+    <div class="column flow">
+        <div class="box flow">
+            <h2>{{ __('Getting started') }}</h2>
+            @if(!$currentUser->entity())
+            <x-expander level="3">
+                <x-slot name="summary">{{ __('Create your entity page') }}</x-slot>
+                <div class="flow">
+                    <p>{{ __('Share more about your organization so that consultants can get to know you.') }}</p>
+                    <p><a class="button" href="{{ localized_route('entities.create') }}">{{ __('Create your page') }}</a></p>
+                </div>
+            </x-expander>
+            @else
+            <x-expander level="3">
+                <x-slot name="summary">{{ __('Create a project page') }}</x-slot>
+                <div class="flow">
+                    <p>{{ __('Create a new project page so that consultants can begin to express their interest in working with you.') }}</p>
+                    <p><a class="button" href="{{ localized_route('projects.create', $currentUser->entity()) }}">{{ __('Create project page') }}</a></p>
+                </div>
+            </x-expander>
+            @endif
+            <x-expander level="3">
+                <x-slot name="summary">{{ __('Learn about engaging the disability community') }}</x-slot>
+                <div class="flow">
+                    <p>{{ __('Browse through our resources and learn more.') }}</p>
+                    <p><a class="button" href="{{ localized_route('collections.index') }}">{{ __('Explore the resource hub') }}</a></p>
+                </div>
+            </x-expander>
+        </div>
+
+        @if($currentUser->entity())
+        <div class="box flow">
+            <h2>{{ __('My entity page') }}</h2>
+            <p>
+                <a href="{{ localized_route('entities.show', $currentUser->entity()) }}"><strong>{{ __('Visit my entity page') }}</strong><br />
+                <a href="{{ localized_route('entities.edit', $currentUser->entity()) }}">{{ __('Edit my entity page') }}</a>
+            </p>
+        </div>
+
+        <div class="box">
+            <h2>{{ __('Notifications') }} <span class="badge">0</span></h2>
+        </div>
+
+        <div class="box">
+            <h2>{{ __('Upcoming meetings') }} <span class="badge">0</span></h2>
+        </div>
+        @endif
+
+    </div>
+
+    <div class="column flow">
+        @if($currentUser->entity())
+        <div class="box">
+            <h2>{{ __('My active projects') }}</h2>
+            @if(count($currentUser->entity()->projects) > 0)
+            {{-- TODO: Display project cards. --}}
+            @else
+            <p>{!! __('You have no active projects right now. :action', ['action' => '<strong><a href="' . localized_route('projects.create', $currentUser->entity()) . '">' . __('Create your first project.') . '</a></strong>']) !!}</p>
+            @endif
+        </div>
+        @else
+        <div class="box">
+            <h2>{{ __('Notifications') }} <span class="badge">0</span></h2>
+        </div>
+
+        <div class="box">
+            <h2>{{ __('Upcoming meetings') }} <span class="badge">0</span></h2>
+        </div>
+        @endif
+    </div>
+</div>

--- a/routes/web.php
+++ b/routes/web.php
@@ -19,9 +19,9 @@ Route::multilingual('/', function () {
     return view('welcome');
 })->name('welcome');
 
-Route::multilingual('/dashboard', function () {
-    return view('dashboard');
-})->middleware(['auth'])->name('dashboard');
+Route::multilingual('/dashboard', [UserController::class, 'dashboard'])
+    ->middleware(['auth'])
+    ->name('dashboard');
 
 Route::multilingual('/account/edit', [UserController::class, 'edit'])
     ->middleware(['auth'])

--- a/tests/Feature/DashboardTest.php
+++ b/tests/Feature/DashboardTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DashboardTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_access_dashboard()
+    {
+        $user = User::factory()->create([
+            'context' => 'consultant',
+        ]);
+
+        $response = $this->actingAs($user)->get(localized_route('dashboard'));
+
+        $response->assertStatus(200);
+        $response->assertSee('Create your community member page');
+
+        $user = User::factory()->create([
+            'context' => 'entity',
+        ]);
+
+        $response = $this->actingAs($user)->get(localized_route('dashboard'));
+
+        $response->assertStatus(200);
+        $response->assertSee('Create your entity page');
+    }
+}


### PR DESCRIPTION
This PR:

- [x] splits the dashboard views into separate partials for the community member or entity representative context
- [x] passes a `$currentUser` variable to the view to prevent the need for multiple calls to the `Auth` facade
- [x] progressively reveals available dashboard actions to community member or entity representatives one they've created their community member or entity pages