### PR TITLE
feat: add new settings page (resolves #224)

### DIFF
--- a/app/Actions/Fortify/UpdateUserProfileInformation.php
+++ b/app/Actions/Fortify/UpdateUserProfileInformation.php
@@ -29,7 +29,6 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
                 Rule::unique('users')->ignore($user->id),
             ],
             'locale' => ['required', Rule::in(config('locales.supported', ['en', 'fr']))],
-            'theme' => ['required', Rule::in(config('themes'))],
         ])->validateWithBag('updateProfileInformation');
 
         if (
@@ -42,11 +41,9 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
                 'name' => $input['name'],
                 'email' => $input['email'],
                 'locale' => $input['locale'],
-                'theme' => $input['theme'],
             ])->save();
         }
 
-        Cookie::queue('theme', $input['theme']);
         Cookie::queue('locale', $input['locale']);
     }
 
@@ -64,7 +61,6 @@ class UpdateUserProfileInformation implements UpdatesUserProfileInformation
             'email' => $input['email'],
             'email_verified_at' => null,
             'locale' => $input['locale'],
-            'theme' => $input['theme'],
         ])->save();
 
         $user->sendEmailVerificationNotification();

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -3,8 +3,12 @@
 namespace App\Http\Controllers;
 
 use App\Http\Requests\DestroyUserRequest;
+use App\Http\Requests\UpdateUserDisplayPreferencesRequest;
 use App\Models\User;
+use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Cookie;
+use Illuminate\View\View;
 
 class UserController extends Controller
 {
@@ -23,7 +27,7 @@ class UserController extends Controller
      *
      * @return \Illuminate\View\View
      */
-    public function dashboard()
+    public function dashboard(): View
     {
         return view('dashboard', [
             'currentUser' => Auth::user(),
@@ -31,11 +35,45 @@ class UserController extends Controller
     }
 
     /**
+     * Show the settings page for the logged-in user.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function settings(): View
+    {
+        return view('users.settings', ['user' => Auth::user()]);
+    }
+
+    /**
      * Show the profile edit view for the logged-in user.
      *
      * @return \Illuminate\View\View
      */
-    public function edit()
+    public function edit(): View
+    {
+        return view('users.edit', [
+            'user' => Auth::user(),
+        ]);
+    }
+
+    /**
+     * Show the roles and permissions edit view for the logged-in user.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function editRolesAndPermissions(): View
+    {
+        return view('users.roles-and-permissions', [
+            'user' => Auth::user(),
+        ]);
+    }
+
+    /**
+     * Show the display preferences edit view for the logged-in user.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function editDisplayPreferences(): View
     {
         $themes = [];
 
@@ -43,9 +81,41 @@ class UserController extends Controller
             $themes[$theme] = __('themes.' . $theme);
         }
 
-        return view('users.edit', [
+        return view('users.display-preferences', [
             'user' => Auth::user(),
             'themes' => $themes,
+        ]);
+    }
+
+    /**
+     * Show the display preferences edit view for the logged-in user.
+     *
+     * @param  \App\Http\Requests\UpdateUserDisplayPreferencesRequest  $request
+     * @return \Illuminate\Http\RedirectResponse
+     */
+    public function updateDisplayPreferences(UpdateUserDisplayPreferencesRequest $request): RedirectResponse
+    {
+        $data = $request->validated();
+
+        Auth::user()->fill($data);
+        Auth::user()->save();
+
+        flash(__('Your display preferences have been updated.'), 'success');
+
+        Cookie::queue('theme', $data['theme']);
+
+        return redirect(\localized_route('users.edit_display_preferences'));
+    }
+
+    /**
+     * Show the notification preferences edit view for the logged-in user.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function editNotificationPreferences(): View
+    {
+        return view('users.notification-preferences', [
+            'user' => Auth::user(),
         ]);
     }
 
@@ -54,9 +124,19 @@ class UserController extends Controller
      *
      * @return \Illuminate\View\View
      */
-    public function admin()
+    public function admin(): View
     {
         return view('users.admin', ['user' => Auth::user()]);
+    }
+
+    /**
+     * Show the account deletion view for the logged-in user.
+     *
+     * @return \Illuminate\View\View
+     */
+    public function delete(): View
+    {
+        return view('users.delete', ['user' => Auth::user()]);
     }
 
     /**

--- a/app/Http/Requests/UpdateUserDisplayPreferencesRequest.php
+++ b/app/Http/Requests/UpdateUserDisplayPreferencesRequest.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+class UpdateUserDisplayPreferencesRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'theme' => ['required', Rule::in(config('themes'))],
+        ];
+    }
+}

--- a/resources/views/components/navigation.blade.php
+++ b/resources/views/components/navigation.blade.php
@@ -76,14 +76,8 @@
                 @endif
 
                 <p>
-                    <x-dropdown-link href="{{ localized_route('users.edit') }}" :active="request()->routeIs(locale() . '.users.edit')">
-                        {{ __('hearth::user.settings') }}
-                    </x-dropdown-link>
-                </p>
-
-                <p>
-                    <x-dropdown-link href="{{ localized_route('users.admin') }}" :active="request()->routeIs(locale() . '.users.admin')">
-                        {{ __('hearth::user.account') }}
+                    <x-dropdown-link href="{{ localized_route('users.settings') }}" :active="request()->routeIs(locale() . '.users.settings')">
+                        {{ __('Settings') }}
                     </x-dropdown-link>
                 </p>
 

--- a/resources/views/users/admin.blade.php
+++ b/resources/views/users/admin.blade.php
@@ -1,8 +1,9 @@
 <x-app-layout>
-    <x-slot name="title">{{ __('hearth::user.account') }}</x-slot>
+    <x-slot name="title">{{ __('Password and security') }}</x-slot>
     <x-slot name="header">
+        <p class="breadcrumb"><x-heroicon-o-chevron-left width="24" height="24" /><a href="{{ localized_route('users.settings') }}">{{ __('Settings') }}</a></p>
         <h1>
-            {{ __('hearth::user.account') }}
+            {{ __('Password and security') }}
         </h1>
     </x-slot>
 
@@ -88,23 +89,4 @@
         @endif
     </x-hearth-password-confirmation>
     @endif
-
-    <h2>{{ __('hearth::user.delete_account') }}</h2>
-
-    <p>{{ __('hearth::user.delete_account_intro') }}</p>
-
-    <form action="{{ localized_route('users.destroy') }}" method="post" novalidate>
-        @csrf
-        @method('delete')
-
-        <div class="field @error('current_password', 'destroyAccount') field--error @enderror">
-            <x-hearth-label for="current_password" :value="__('hearth::auth.label_current_password')" />
-            <x-hearth-input id="current_password" type="password" name="current_password" required />
-            <x-hearth-error for="current_password" bag="destroyAccount" />
-        </div>
-
-        <x-hearth-button>
-            {{ __('hearth::user.action_delete_account') }}
-        </x-hearth-button>
-    </form>
 </x-app-layout>

--- a/resources/views/users/delete.blade.php
+++ b/resources/views/users/delete.blade.php
@@ -1,0 +1,29 @@
+<x-app-layout>
+    <x-slot name="title">{{ __('Delete account') }}</x-slot>
+    <x-slot name="header">
+        <p class="breadcrumb"><x-heroicon-o-chevron-left width="24" height="24" /><a href="{{ localized_route('users.settings') }}">{{ __('Settings') }}</a></p>
+        <h1>
+            {{ __('Delete account') }}
+        </h1>
+    </x-slot>
+
+    <!-- Form Validation Errors -->
+    @include('partials.validation-errors')
+
+    <p>{{ __('hearth::user.delete_account_intro') }}</p>
+
+    <form action="{{ localized_route('users.destroy') }}" method="post" novalidate>
+        @csrf
+        @method('delete')
+
+        <div class="field @error('current_password', 'destroyAccount') field--error @enderror">
+            <x-hearth-label for="current_password" :value="__('hearth::auth.label_current_password')" />
+            <x-hearth-input id="current_password" type="password" name="current_password" required />
+            <x-hearth-error for="current_password" bag="destroyAccount" />
+        </div>
+
+        <x-hearth-button>
+            {{ __('hearth::user.action_delete_account') }}
+        </x-hearth-button>
+    </form>
+</x-app-layout>

--- a/resources/views/users/display-preferences.blade.php
+++ b/resources/views/users/display-preferences.blade.php
@@ -1,0 +1,37 @@
+<x-app-layout>
+    <x-slot name="title">{{ __('Display preferences') }}</x-slot>
+    <x-slot name="header">
+        <p class="breadcrumb"><x-heroicon-o-chevron-left width="24" height="24" /><a href="{{ localized_route('users.settings') }}">{{ __('Settings') }}</a></p>
+        <h1>
+            {{ __('Display preferences') }}
+        </h1>
+    </x-slot>
+
+    <!-- Form Validation Errors -->
+    @include('partials.validation-errors')
+
+    <form action="{{ localized_route('users.update_display_preferences') }}" method="POST" novalidate>
+        @csrf
+
+        @method('PUT')
+
+        <div class="field" x-data="previewHandler()">
+            <x-hearth-label for="theme" :value="__('themes.label_theme')" />
+            <x-hearth-select x-model.string="theme" id="theme" name="theme" :options="$themes" :selected="old('theme', $user->theme)" @change="preview()" />
+            <script>
+                function previewHandler() {
+                    return {
+                        theme: '{{ $user->theme }}',
+                        preview() {
+                            document.documentElement.dataset.theme = this.theme;
+                        }
+                    }
+                }
+            </script>
+        </div>
+
+        <x-hearth-button>
+            {{ __('Save changes') }}
+        </x-hearth-button>
+    </form>
+</x-app-layout>

--- a/resources/views/users/edit.blade.php
+++ b/resources/views/users/edit.blade.php
@@ -1,8 +1,9 @@
 <x-app-layout>
-    <x-slot name="title">{{ __('hearth::user.settings') }}</x-slot>
+    <x-slot name="title">{{ __('Basic information') }}</x-slot>
     <x-slot name="header">
+        <p class="breadcrumb"><x-heroicon-o-chevron-left width="24" height="24" /><a href="{{ localized_route('users.settings') }}">{{ __('Settings') }}</a></p>
         <h1>
-            {{ __('hearth::user.settings') }}
+            {{ __('Basic information') }}
         </h1>
     </x-slot>
 
@@ -30,21 +31,6 @@
             <x-hearth-label for="locale" :value="__('hearth::user.label_locale')" />
             <x-hearth-locale-select name="locale" :selected="old('locale', $user->locale)" />
             <x-hearth-error for="locale" bag="updateProfileInformation" />
-        </div>
-
-        <div class="field" x-data="previewHandler()">
-            <x-hearth-label for="theme" :value="__('themes.label_theme')" />
-            <x-hearth-select x-model.string="theme" id="theme" name="theme" :options="$themes" :selected="old('theme', $user->theme)" @change="preview()" />
-            <script>
-                function previewHandler() {
-                    return {
-                        theme: '{{ $user->theme }}',
-                        preview() {
-                            document.documentElement.dataset.theme = this.theme;
-                        }
-                    }
-                }
-            </script>
         </div>
 
         <x-hearth-button>

--- a/resources/views/users/notification-preferences.blade.php
+++ b/resources/views/users/notification-preferences.blade.php
@@ -10,5 +10,6 @@
     <!-- Form Validation Errors -->
     @include('partials.validation-errors')
 
-    <p>TODO.</p>
+    {{-- TODO --}}
+    <p>Coming soon!</p>
 </x-app-layout>

--- a/resources/views/users/notification-preferences.blade.php
+++ b/resources/views/users/notification-preferences.blade.php
@@ -1,0 +1,14 @@
+<x-app-layout>
+    <x-slot name="title">{{ __('Notification preferences') }}</x-slot>
+    <x-slot name="header">
+        <p class="breadcrumb"><x-heroicon-o-chevron-left width="24" height="24" /><a href="{{ localized_route('users.settings') }}">{{ __('Settings') }}</a></p>
+        <h1>
+            {{ __('Notification preferences') }}
+        </h1>
+    </x-slot>
+
+    <!-- Form Validation Errors -->
+    @include('partials.validation-errors')
+
+    <p>TODO.</p>
+</x-app-layout>

--- a/resources/views/users/roles-and-permissions.blade.php
+++ b/resources/views/users/roles-and-permissions.blade.php
@@ -1,0 +1,14 @@
+<x-app-layout>
+    <x-slot name="title">{{ __('Roles and permissions') }}</x-slot>
+    <x-slot name="header">
+        <p class="breadcrumb"><x-heroicon-o-chevron-left width="24" height="24" /><a href="{{ localized_route('users.settings') }}">{{ __('Settings') }}</a></p>
+        <h1>
+            {{ __('Roles and permissions') }}
+        </h1>
+    </x-slot>
+
+    <!-- Form Validation Errors -->
+    @include('partials.validation-errors')
+
+    <p>TODO.</p>
+</x-app-layout>

--- a/resources/views/users/roles-and-permissions.blade.php
+++ b/resources/views/users/roles-and-permissions.blade.php
@@ -9,6 +9,6 @@
 
     <!-- Form Validation Errors -->
     @include('partials.validation-errors')
-
-    <p>TODO.</p>
+    {{-- TODO --}}
+    <p>Coming soon!</p>
 </x-app-layout>

--- a/resources/views/users/roles-and-permissions.blade.php
+++ b/resources/views/users/roles-and-permissions.blade.php
@@ -9,6 +9,7 @@
 
     <!-- Form Validation Errors -->
     @include('partials.validation-errors')
+
     {{-- TODO --}}
     <p>Coming soon!</p>
 </x-app-layout>

--- a/resources/views/users/settings.blade.php
+++ b/resources/views/users/settings.blade.php
@@ -13,7 +13,7 @@
         <li><a href="{{ localized_route('users.edit') }}">{{ __('Basic information') }}</a></li>
         <li><a href="{{ localized_route('users.edit_roles_and_permissions') }}">{{ __('Roles and permissions') }}</a></li>
         <li><a href="{{ localized_route('users.edit_display_preferences') }}">{{ __('Display preferences') }}</a></li>
-        <li><a href="{{ localized_route('users.edit-notification-preferences') }}">{{ __('Notification preferences') }}</a></li>
+        <li><a href="{{ localized_route('users.edit_notification_preferences') }}">{{ __('Notification preferences') }}</a></li>
         <li><a href="{{ localized_route('users.admin') }}">{{ __('Password and security') }}</a></li>
         <li><a href="{{ localized_route('users.delete') }}">{{ __('Delete account') }}</a></li>
     </ul>

--- a/resources/views/users/settings.blade.php
+++ b/resources/views/users/settings.blade.php
@@ -1,0 +1,21 @@
+<x-app-layout>
+    <x-slot name="title">{{ __('Settings') }}</x-slot>
+    <x-slot name="header">
+        <h1>
+            {{ __('Settings') }}
+        </h1>
+    </x-slot>
+
+    <!-- Form Validation Errors -->
+    @include('partials.validation-errors')
+
+    <ul role="list">
+        <li><a href="{{ localized_route('users.edit') }}">{{ __('Basic information') }}</a></li>
+        <li><a href="{{ localized_route('users.edit_roles_and_permissions') }}">{{ __('Roles and permissions') }}</a></li>
+        <li><a href="{{ localized_route('users.edit_display_preferences') }}">{{ __('Display preferences') }}</a></li>
+        <li><a href="{{ localized_route('users.edit-notification-preferences') }}">{{ __('Notification preferences') }}</a></li>
+        <li><a href="{{ localized_route('users.admin') }}">{{ __('Password and security') }}</a></li>
+        <li><a href="{{ localized_route('users.delete') }}">{{ __('Delete account') }}</a></li>
+    </ul>
+
+</x-app-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,7 +47,7 @@ Route::multilingual('/settings/display-preferences', [UserController::class, 'up
 
 Route::multilingual('/settings/notifications', [UserController::class, 'editNotificationPreferences'])
     ->middleware(['auth'])
-    ->name('users.edit-notification-preferences');
+    ->name('users.edit_notification_preferences');
 
 Route::multilingual('/settings/change-password', [UserController::class, 'admin'])
     ->middleware(['auth'])

--- a/routes/web.php
+++ b/routes/web.php
@@ -23,13 +23,39 @@ Route::multilingual('/dashboard', [UserController::class, 'dashboard'])
     ->middleware(['auth'])
     ->name('dashboard');
 
-Route::multilingual('/account/edit', [UserController::class, 'edit'])
+Route::multilingual('/settings', [UserController::class, 'settings'])
+    ->middleware(['auth'])
+    ->name('users.settings');
+
+Route::multilingual('/settings/basic-information', [UserController::class, 'edit'])
     ->middleware(['auth'])
     ->name('users.edit');
 
-Route::multilingual('/account/admin', [UserController::class, 'admin'])
+Route::multilingual('/settings/roles-and-permissions', [UserController::class, 'editRolesAndPermissions'])
+    ->middleware(['auth'])
+    ->name('users.edit_roles_and_permissions');
+
+Route::multilingual('/settings/display-preferences', [UserController::class, 'editDisplayPreferences'])
+    ->middleware(['auth'])
+    ->name('users.edit_display_preferences');
+
+
+Route::multilingual('/settings/display-preferences', [UserController::class, 'updateDisplayPreferences'])
+    ->method('put')
+    ->middleware(['auth'])
+    ->name('users.update_display_preferences');
+
+Route::multilingual('/settings/notifications', [UserController::class, 'editNotificationPreferences'])
+    ->middleware(['auth'])
+    ->name('users.edit-notification-preferences');
+
+Route::multilingual('/settings/change-password', [UserController::class, 'admin'])
     ->middleware(['auth'])
     ->name('users.admin');
+
+Route::multilingual('/settings/delete-account', [UserController::class, 'delete'])
+    ->middleware(['auth'])
+    ->name('users.delete');
 
 Route::multilingual('/account/delete', [UserController::class, 'destroy'])
     ->method('delete')

--- a/tests/Feature/AccountDeletionTest.php
+++ b/tests/Feature/AccountDeletionTest.php
@@ -14,14 +14,10 @@ class AccountDeletionTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $response = $this->post(localized_route('login-store'), [
-            'email' => $user->email,
-            'password' => 'password',
-        ]);
+        $response = $this->actingAs($user)->get(localized_route('users.delete'));
+        $response->assertOk();
 
-        $this->assertAuthenticated();
-
-        $response = $this->from(localized_route('users.admin'))->delete(localized_route('users.destroy'), [
+        $response = $this->actingAs($user)->from(localized_route('users.delete'))->delete(localized_route('users.destroy'), [
             'current_password' => 'password',
         ]);
 
@@ -34,14 +30,7 @@ class AccountDeletionTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $response = $this->post(localized_route('login-store'), [
-            'email' => $user->email,
-            'password' => 'password',
-        ]);
-
-        $this->assertAuthenticated();
-
-        $response = $this->from(localized_route('users.admin'))->delete(localized_route('users.destroy'), [
+        $response = $this->actingAs($user)->from(localized_route('users.admin'))->delete(localized_route('users.destroy'), [
             'current_password' => 'wrong_password',
         ]);
 

--- a/tests/Feature/AuthenticationTest.php
+++ b/tests/Feature/AuthenticationTest.php
@@ -51,18 +51,4 @@ class AuthenticationTest extends TestCase
 
         $this->assertGuest();
     }
-
-    public function test_users_can_edit_own_profiles()
-    {
-        $user = User::factory()->create();
-
-        $response = $this->actingAs($user)->get(localized_route('users.edit'));
-        $response->assertOk();
-    }
-
-    public function test_guests_can_not_edit_profiles()
-    {
-        $response = $this->get(localized_route('users.edit'));
-        $response->assertRedirect(localized_route('login'));
-    }
 }

--- a/tests/Feature/PasswordChangeTest.php
+++ b/tests/Feature/PasswordChangeTest.php
@@ -14,38 +14,48 @@ class PasswordChangeTest extends TestCase
     {
         $user = User::factory()->create();
 
-        $response = $this->from(localized_route('users.admin'))->actingAs($user)->put(localized_route('user-password.update'), [
-            'current_password' => 'password',
-            'password' => 'new_password',
-            'password_confirmation' => 'new_password',
-        ]);
+        $response = $this->actingAs($user)->get(localized_route("users.admin"));
 
-        $response->assertRedirect(localized_route('users.admin'));
+        $response->assertOk();
+
+        $response = $this->from(localized_route("users.admin"))
+            ->actingAs($user)
+            ->put(localized_route("user-password.update"), [
+                "current_password" => "password",
+                "password" => "new_password",
+                "password_confirmation" => "new_password",
+            ]);
+
+        $response->assertRedirect(localized_route("users.admin"));
     }
 
     public function test_password_cannot_be_updated_with_incorrect_current_password()
     {
         $user = User::factory()->create();
 
-        $response = $this->from(localized_route('users.admin'))->actingAs($user)->put(localized_route('user-password.update'), [
-            'current_password' => 'wrong_password',
-            'password' => 'new_password',
-            'password_confirmation' => 'new_password',
-        ]);
+        $response = $this->from(localized_route("users.admin"))
+            ->actingAs($user)
+            ->put(localized_route("user-password.update"), [
+                "current_password" => "wrong_password",
+                "password" => "new_password",
+                "password_confirmation" => "new_password",
+            ]);
 
-        $response->assertRedirect(localized_route('users.admin'));
+        $response->assertRedirect(localized_route("users.admin"));
     }
 
     public function test_password_cannot_be_updated_with_password_that_do_not_match()
     {
         $user = User::factory()->create();
 
-        $response = $this->from(localized_route('users.admin'))->actingAs($user)->put(localized_route('user-password.update'), [
-            'current_password' => 'password',
-            'password' => 'new_password',
-            'password_confirmation' => 'different_new_password',
-        ]);
+        $response = $this->from(localized_route("users.admin"))
+            ->actingAs($user)
+            ->put(localized_route("user-password.update"), [
+                "current_password" => "password",
+                "password" => "new_password",
+                "password_confirmation" => "different_new_password",
+            ]);
 
-        $response->assertRedirect(localized_route('users.admin'));
+        $response->assertRedirect(localized_route("users.admin"));
     }
 }

--- a/tests/Feature/UserTest.php
+++ b/tests/Feature/UserTest.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Tests\TestCase;
+
+class UserTest extends TestCase
+{
+    public function test_users_can_access_settings()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(localized_route('users.settings'));
+        $response->assertOk();
+    }
+
+    public function test_guests_can_not_access_settings()
+    {
+        $response = $this->get(localized_route('users.settings'));
+        $response->assertRedirect(localized_route('login'));
+    }
+
+    public function test_users_can_edit_basic_information()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(localized_route('users.edit'));
+        $response->assertOk();
+    }
+
+    public function test_guests_can_not_edit_basic_information()
+    {
+        $response = $this->get(localized_route('users.edit'));
+        $response->assertRedirect(localized_route('login'));
+    }
+
+    public function test_users_can_edit_roles_and_permissions()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(localized_route('users.edit_roles_and_permissions'));
+        $response->assertOk();
+    }
+
+    public function test_guests_can_not_edit_roles_and_permissions()
+    {
+        $response = $this->get(localized_route('users.edit_roles_and_permissions'));
+        $response->assertRedirect(localized_route('login'));
+    }
+
+    public function test_users_can_edit_display_preferences()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(localized_route('users.edit_display_preferences'));
+        $response->assertOk();
+
+        $response = $this->actingAs($user)->put(localized_route('users.update_display_preferences'), [
+            'theme' => 'system',
+        ]);
+
+        $response->assertRedirect(localized_route('users.edit_display_preferences'));
+    }
+
+    public function test_guests_can_not_edit_display_preferences()
+    {
+        $response = $this->get(localized_route('users.edit_display_preferences'));
+        $response->assertRedirect(localized_route('login'));
+    }
+
+    public function test_users_can_edit_notification_preferences()
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->get(localized_route('users.edit_notification_preferences'));
+        $response->assertOk();
+    }
+
+    public function test_guests_can_not_edit_notification_preferences()
+    {
+        $response = $this->get(localized_route('users.edit_notification_preferences'));
+        $response->assertRedirect(localized_route('login'));
+    }
+}


### PR DESCRIPTION
This PR replaces the "settings" and "account" pages with a main settings page linking to the following:

- [x] Basic information
- Roles and permissions (stubbed, follow up in https://github.com/accessibility-exchange/platform/issues/254)
- [x] Display preferences
- Notification preferences (stubbed, follow up in https://github.com/accessibility-exchange/platform/issues/255)
- [x] Change password
- [x] Delete account