### PR TITLE
Feat/create scheduler

### DIFF
--- a/.deploy/accessibility-app/entrypoint.sh
+++ b/.deploy/accessibility-app/entrypoint.sh
@@ -15,20 +15,7 @@ then
 
   touch $FILES_PATH/../deploy.lock
 
-  if [[ "$APP_ENV" == "production" ]]
-  then
-    php artisan migrate --step
-  else
-    php artisan migrate:fresh --step 
-    php artisan db:seed DevSeeder
-  fi
-
-  php artisan google-fonts:fetch
-  php artisan storage:link
-  php artisan cache:clear
-  php artisan view:clear
-  php artisan route:cache
-  php artisan config:cache
+  php artisan deploy:initial
   
 fi
 

--- a/app/Console/Commands/DatabaseRefresh.php
+++ b/app/Console/Commands/DatabaseRefresh.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class DatabaseRefresh extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'db:refresh';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Refreshes and seeds the database for development work.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        $this->call('migrate:fresh', ['--force']); 
+        $this->call('db:seed', ['DevSeeder', '--force']);
+    }
+}

--- a/app/Console/Commands/DatabaseRefresh.php
+++ b/app/Console/Commands/DatabaseRefresh.php
@@ -27,7 +27,7 @@ class DatabaseRefresh extends Command
      */
     public function handle()
     {
-        $this->call('migrate:fresh', ['--force']); 
+        $this->call('migrate:fresh', ['--force']);
         $this->call('db:seed', ['DevSeeder', '--force']);
     }
 }

--- a/app/Console/Commands/DeployInitial.php
+++ b/app/Console/Commands/DeployInitial.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+
+class DeployInitial extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'deploy:initial';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'All commands that should be run when a container boots.';
+
+    /**
+     * Execute the console command.
+     *
+     * @return int
+     */
+    public function handle()
+    {
+        // split migrate commands between production and development versions
+        if (config('app.env') === 'production') {
+            $this->call('migrate', ['--step']); 
+        } else {
+            $this->call('migrate:fresh', ['--step', '--force']); 
+            $this->call('db:seed', ['DevSeeder', '--force']); 
+        }
+      
+        $this->call('google-fonts:fetch'); 
+        $this->call('storage:link'); 
+        $this->call('cache:clear'); 
+        $this->call('view:clear'); 
+        $this->call('optimize'); 
+        $this->call('event:cache'); 
+    }
+}

--- a/app/Console/Commands/DeployInitial.php
+++ b/app/Console/Commands/DeployInitial.php
@@ -31,8 +31,7 @@ class DeployInitial extends Command
         if (config('app.env') === 'production') {
             $this->call('migrate', ['--step']);
         } else {
-            $this->call('migrate:fresh', ['--step', '--force']);
-            $this->call('db:seed', ['DevSeeder', '--force']);
+            $this->call('db:refresh');
         }
 
         $this->call('google-fonts:fetch');

--- a/app/Console/Commands/DeployInitial.php
+++ b/app/Console/Commands/DeployInitial.php
@@ -29,17 +29,17 @@ class DeployInitial extends Command
     {
         // split migrate commands between production and development versions
         if (config('app.env') === 'production') {
-            $this->call('migrate', ['--step']); 
+            $this->call('migrate', ['--step']);
         } else {
-            $this->call('migrate:fresh', ['--step', '--force']); 
-            $this->call('db:seed', ['DevSeeder', '--force']); 
+            $this->call('migrate:fresh', ['--step', '--force']);
+            $this->call('db:seed', ['DevSeeder', '--force']);
         }
-      
-        $this->call('google-fonts:fetch'); 
-        $this->call('storage:link'); 
-        $this->call('cache:clear'); 
-        $this->call('view:clear'); 
-        $this->call('optimize'); 
-        $this->call('event:cache'); 
+
+        $this->call('google-fonts:fetch');
+        $this->call('storage:link');
+        $this->call('cache:clear');
+        $this->call('view:clear');
+        $this->call('optimize');
+        $this->call('event:cache');
     }
 }

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -24,7 +24,10 @@ class Kernel extends ConsoleKernel
      */
     protected function schedule(Schedule $schedule)
     {
-        // $schedule->command('inspire')->hourly();
+        $schedule->command('db:refresh') // use custom command to make sure that the commands are chained
+            ->daily() // Run daily at midnight
+            ->environments(['staging', 'local']) // only run for APP_ENV tagged staging or local
+            ->onOneServer(); // run only on a single server at once
     }
 
     /**


### PR DESCRIPTION
Added new command `deploy:initial` which is where we will put everything that we need to run at boot time. Then we only add this command into entrypoint script and make all changes within this command.

Made update to entrypoint script.

Added new command `db:refresh` which chains `migrate:fresh` & `db:seed` commands.

Added schedule to run command `db:refresh` to run nightly on environments tagged with **staging** or **local**.