### PR TITLE
fix: rename language accordions (resolves #669)

### DIFF
--- a/resources/views/components/language-changer.blade.php
+++ b/resources/views/components/language-changer.blade.php
@@ -2,7 +2,8 @@
     'modelName' => 'name'
 ])
 
-<x-expander level="2" :summary="__('Change language')">
+@if(count($model->languages) > 1)
+<x-expander level="2" :summary="__('Change page language')">
     <h3>{{ __('Available languages') }}</h3>
     <ul role="list">
     @foreach($model->languages as $code)
@@ -20,3 +21,4 @@
 
     <p><a href="#TODO">{{ __('Contact support') }}</a></p>
 </x-expander>
+@endif

--- a/resources/views/components/translation-manager.blade.php
+++ b/resources/views/components/translation-manager.blade.php
@@ -1,4 +1,4 @@
-<x-expander level="2" :summary="__('Language settings')" x-data>
+<x-expander level="2" :summary="__('Page translations')" x-data>
     @foreach($model->languages as $language)
         <div x-data="modal()">
             <p class="repel">{{ get_language_exonym($language) }}@if(count($model->languages) > 1)<button class="secondary" @click="showModal">{{ __('Remove') }}<span class="visually-hidden"> {{ get_language_exonym($language) }}</span></button>@endif</p>

--- a/resources/views/individuals/show.blade.php
+++ b/resources/views/individuals/show.blade.php
@@ -55,11 +55,7 @@
         </div>
     </x-slot>
 
-    @can('update', $individual)
-        <x-translation-manager :model="$individual" />
-    @else
-        <x-language-changer :model="$individual" />
-    @endcan
+    <x-language-changer :model="$individual" />
 
     <div class="with-sidebar">
         <nav class="secondary" aria-labelledby="individual">

--- a/resources/views/organizations/show-language-selection.blade.php
+++ b/resources/views/organizations/show-language-selection.blade.php
@@ -4,7 +4,7 @@
     <x-slot name="header">
         <p class="h2">{{ __('Create organization profile') }}</p>
         <h1>
-            {{ __('Languages available') }}
+            {{ __('Page translations') }}
         </h1>
     </x-slot>
 

--- a/resources/views/organizations/show.blade.php
+++ b/resources/views/organizations/show.blade.php
@@ -57,11 +57,7 @@
         </div>
     </x-slot>
 
-    @can('update', $organization)
-        <x-translation-manager :model="$organization" />
-    @else
-        <x-language-changer :model="$organization" />
-    @endcan
+    <x-language-changer :model="$organization" />
 
     <div class="with-sidebar">
         <nav class="secondary" aria-labelledby="regulated-organization">

--- a/resources/views/regulated-organizations/show-language-selection.blade.php
+++ b/resources/views/regulated-organizations/show-language-selection.blade.php
@@ -4,7 +4,7 @@
     <x-slot name="header">
         <p class="h2">{{ __('Create regulated organization profile') }}</p>
         <h1>
-            {{ __('Languages available') }}
+            {{ __('Page translations') }}
         </h1>
     </x-slot>
 

--- a/resources/views/regulated-organizations/show.blade.php
+++ b/resources/views/regulated-organizations/show.blade.php
@@ -57,11 +57,7 @@
         </div>
     </x-slot>
 
-    @can('update', $regulatedOrganization)
-        <x-translation-manager :model="$regulatedOrganization" />
-    @else
-        <x-language-changer :model="$regulatedOrganization" />
-    @endcan
+    <x-language-changer :model="$regulatedOrganization" />
 
     <div class="with-sidebar">
         <nav class="secondary" aria-labelledby="regulated-organization">


### PR DESCRIPTION
- [x] Renames language accordions
- [x] When viewing your own page, you should see the language switcher rather than the language picker