### PR TITLE
ci: create PR with changelog instead of auto-committing

### DIFF
--- a/.github/workflows/update-changelog.yml
+++ b/.github/workflows/update-changelog.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: dev
+          token: ${{ secrets.PAT }}
 
       - name: Update changelog
         uses: stefanzweifel/changelog-updater-action@v1
@@ -22,9 +23,13 @@ jobs:
           release-notes: ${{ github.event.release.body }}
           latest-version: ${{ github.event.release.name }}
 
-      - name: Commit updated changelog
-        uses: stefanzweifel/git-auto-commit-action@v4
+      - name: Create pull request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
         with:
-          branch: dev
-          commit_message: "chore(docs): update changelog"
-          file_pattern: CHANGELOG.md
+          commit-message: "chore(docs): update changelog"
+          branch: chore/changelog
+          delete-branch: true
+          title: 'chore(docs): update changelog'
+          labels: documentation
+          team-reviewers: maintainers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,47 @@
 
 All notable changes to this project will be documented in this file.
 
+## v1.0.0-alpha3 - 2022-08-08
+
+### What's Changed
+
+* chore: switch from PHP CS Fixer to Laravel Pint by @greatislander in https://github.com/accessibility-exchange/platform/pull/555
+* feat: expand language list using umpirsky/language-list by @greatislander in https://github.com/accessibility-exchange/platform/pull/557
+* fix: allow editing of Individual page (fix #558) by @greatislander in https://github.com/accessibility-exchange/platform/pull/559
+* fix: address issues with working language selection (fix #560) by @greatislander in https://github.com/accessibility-exchange/platform/pull/561
+* chore: switch assets to Vite by @greatislander in https://github.com/accessibility-exchange/platform/pull/564
+* feat: encrypt individual data (towards #111) by @greatislander in https://github.com/accessibility-exchange/platform/pull/563
+* feat: update Individual page creation with new constituency relationships by @greatislander in https://github.com/accessibility-exchange/platform/pull/566
+* feat: support viewing individual pages in different languages by @greatislander in https://github.com/accessibility-exchange/platform/pull/571
+* feat: settings (resolves #317) by @greatislander in https://github.com/accessibility-exchange/platform/pull/582
+* feat: consolidate database migrations (resolves #598) by @greatislander in https://github.com/accessibility-exchange/platform/pull/600
+* fix: ensure that empty nested arrays aren't saved (resolves #506) by @greatislander in https://github.com/accessibility-exchange/platform/pull/610
+* feat: clean up orphaned CSS by @greatislander in https://github.com/accessibility-exchange/platform/pull/621
+* fix: differentiate radio buttons from checkboxes (resolves #634) by @greatislander in https://github.com/accessibility-exchange/platform/pull/635
+* fix: resolve various signup issues by @greatislander in https://github.com/accessibility-exchange/platform/pull/636
+* fix: add validation message for phone numbers (fix #639) by @greatislander in https://github.com/accessibility-exchange/platform/pull/649
+* ci: changed caching declaration (#662) by @marvinroman in https://github.com/accessibility-exchange/platform/pull/686
+* fix: prevent participants from creating pages (fix #638) by @greatislander in https://github.com/accessibility-exchange/platform/pull/692
+* fix: persist individual meeting types (fix #643) by @greatislander in https://github.com/accessibility-exchange/platform/pull/694
+* fix: individual communication and consultation preferences (fix #644) by @greatislander in https://github.com/accessibility-exchange/platform/pull/695
+* fix: success message in notification settings is cut off (fix #664) by @greatislander in https://github.com/accessibility-exchange/platform/pull/696
+* fix: update success message on save, redirect to published page by @greatislander in https://github.com/accessibility-exchange/platform/pull/698
+* fix: remove unused links, add contact info and socials by @greatislander in https://github.com/accessibility-exchange/platform/pull/699
+* feat: user projects page (resolves #652, resolves #653, resolves #654, resolves #655) by @greatislander in https://github.com/accessibility-exchange/platform/pull/691
+* feat: add footer CTA to browse all projects, add CTA to create project by @greatislander in https://github.com/accessibility-exchange/platform/pull/704
+* chore: add seeders for testing (part 1 of 2) by @greatislander in https://github.com/accessibility-exchange/platform/pull/707
+* feat: create and edit projects by @greatislander in https://github.com/accessibility-exchange/platform/pull/706
+* fix: rename language accordions (resolves #669) by @greatislander in https://github.com/accessibility-exchange/platform/pull/697
+* feat: update project views (resolves #319) by @greatislander in https://github.com/accessibility-exchange/platform/pull/708
+* fix: resolve 500 error on Regulated Organization projects tab (fix #710) by @greatislander in https://github.com/accessibility-exchange/platform/pull/711
+* chore: seed projects by @greatislander in https://github.com/accessibility-exchange/platform/pull/712
+
+### New Contributors
+
+* @marvinroman made their first contribution in [#686](https://github.com/accessibility-exchange/platform/pull/686)
+
+**Full Changelog**: https://github.com/accessibility-exchange/platform/compare/v1.0.0-alpha2...v1.0.0-alpha3
+
 ## v1.0.0-alpha2 - 2022-06-23
 
 ### What's Changed
@@ -31,7 +72,7 @@ Initial alpha release, incorporating the [Community Members](https://github.com/
 
 ### New Contributors
 
-* [@greatislander](https://github.com/greatislander) made their first contribution in https://github.com/accessibility-exchange/platform/pull/1
+* @greatislander made their first contribution in https://github.com/accessibility-exchange/platform/pull/1
 * [@gtirloni](https://github.com/gtirloni) made their first contribution in https://github.com/accessibility-exchange/platform/pull/6
 
 **Full Changelog**: https://github.com/accessibility-exchange/platform/commits/v1.0.0-alpha1


### PR DESCRIPTION
Right now there's a GitHub Action set up to copy the changelog from new releases into the project's CHANGELOG.md file. It isn't working because `dev` is a protected branch. This PR fixes the GitHub Action (it will open a PR with the updated CHANGELOG.md instead of trying to commit directly) and updates the CHANGELOG.md with changes  from 1.0.0-alpha.3.