### PR TITLE
fix: clarify language related to leaving organizations (fix #670, fix #676)

### DIFF
--- a/resources/lang/en.json
+++ b/resources/lang/en.json
@@ -478,6 +478,8 @@
     "Learn more about disability": "Learn more about disability",
     "Learn more about getting input for your projects": "Learn more about getting input for your projects",
     "Learn more about these roles": "Learn more about these roles",
+    "Leave :membershipable": "Leave :membershipable",
+    "Leave organization": "Leave organization",
     "Lived and living experiences": "Lived and living experiences",
     "Lived experience": "Lived experience",
     "Lived experience (optional)": "Lived experience (optional)",

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -147,7 +147,7 @@ return [
             'length' => 'The :attribute must be at least :length characters.',
         ],
         'membership' => [
-            'not_last_admin' => 'There must be at least one administrator.',
+            'not_last_admin' => 'Sorry, you cannot leave an organization if you are the only administrator. Please make another member from your organization an administrator.',
         ],
         'organization' => [
             'name_exists' => 'An organization with this name already exists.',

--- a/resources/lang/fr.json
+++ b/resources/lang/fr.json
@@ -478,6 +478,8 @@
     "Learn more about disability": "Learn more about disability",
     "Learn more about getting input for your projects": "Learn more about getting input for your projects",
     "Learn more about these roles": "Learn more about these roles",
+    "Leave :membershipable": "",
+    "Leave organization": "",
     "Lived and living experiences": "Lived and living experiences",
     "Lived experience": "Lived experience",
     "Lived experience (optional)": "Lived experience (optional)",

--- a/resources/views/settings/roles-and-permissions.blade.php
+++ b/resources/views/settings/roles-and-permissions.blade.php
@@ -79,8 +79,8 @@
                         <form action="{{ route('memberships.destroy', $member->membership->id) }}" method="POST">
                             @csrf
                             @method('delete')
-                            <button class="secondary" :aria-label="__('Remove :user from :membershipable', ['user' => $joiner->name, 'membershipable' => $membershipable->name])">
-                                {{ __('Remove') }}
+                            <button class="secondary" aria-label="{{ $member->id === $user->id ? __('Leave :membershipable', ['membershipable' => $membershipable->name]) : __('Remove :user from :membershipable', ['user' => $member->name, 'membershipable' => $membershipable->name]) }}">
+                                {{ $member->id === $user->id ? __('Leave organization') : __('Remove') }}
                             </button>
                         </form>
                     </td>


### PR DESCRIPTION
Button text for user to remove themselves from an organization:

> Leave organization

Screen reader text for user to remove themselves from an organization:

> Leave `<organization name>`

Error message for leaving organization as sole administrator:

> Sorry, you cannot leave an organization if you are the only administrator. Please make another member from your organization an administrator.